### PR TITLE
net: hack DNS config support

### DIFF
--- a/src/net/conf.go
+++ b/src/net/conf.go
@@ -98,7 +98,12 @@ func initConfVal() {
 		confVal.nss = parseNSSConfFile("/etc/nsswitch.conf")
 	}
 
-	confVal.resolv = dnsReadConfig("/etc/resolv.conf")
+	if runtime.GOOS == "haiku" {
+		confVal.resolv = dnsReadConfig("/boot/system/settings/network/resolv.conf")
+	} else {
+		confVal.resolv = dnsReadConfig("/etc/resolv.conf")
+	}
+
 	if confVal.resolv.err != nil && !os.IsNotExist(confVal.resolv.err) &&
 		!os.IsPermission(confVal.resolv.err) {
 		// If we can't read the resolv.conf file, assume it

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -17,6 +17,7 @@ package net
 import (
 	"context"
 	"errors"
+	"internal/goos"
 	"internal/itoa"
 	"io"
 	"os"
@@ -338,7 +339,11 @@ func (conf *resolverConfig) init() {
 	// resolv.conf twice the first time.
 	conf.dnsConfig = systemConf().resolv
 	if conf.dnsConfig == nil {
-		conf.dnsConfig = dnsReadConfig("/etc/resolv.conf")
+		if goos.GOOS == "haiku" {
+			conf.dnsConfig = dnsReadConfig("/boot/system/settings/network/resolv.conf")
+		} else {
+			conf.dnsConfig = dnsReadConfig("/etc/resolv.conf")
+		}
 	}
 	conf.lastChecked = time.Now()
 

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -17,10 +17,10 @@ package net
 import (
 	"context"
 	"errors"
-	"internal/goos"
 	"internal/itoa"
 	"io"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 

--- a/src/net/dnsclient_unix.go
+++ b/src/net/dnsclient_unix.go
@@ -339,7 +339,7 @@ func (conf *resolverConfig) init() {
 	// resolv.conf twice the first time.
 	conf.dnsConfig = systemConf().resolv
 	if conf.dnsConfig == nil {
-		if goos.GOOS == "haiku" {
+		if runtime.GOOS == "haiku" {
 			conf.dnsConfig = dnsReadConfig("/boot/system/settings/network/resolv.conf")
 		} else {
 			conf.dnsConfig = dnsReadConfig("/etc/resolv.conf")


### PR DESCRIPTION
By default Go looks for `/stc/resolv.conf` file, and if it's not available then it tries to use localhost IPs (`127.0.0.1:53`  and `::1:53`)

Haiku stores this file under `/boot/system/settings/network/resolv.conf`.

Example with `go mod tidy`
<details>

<summary>before</summary>

```test
go: downloading github.com/gojuno/go.morton v0.0.0-20180202102823-94709bd871ce
go: downloading github.com/spf13/pflag v1.0.5
github.com/stuntkit/stunt_gp_tools/cmd/dir_pack imports
        github.com/spf13/pflag: github.com/spf13/pflag@v1.0.5: Get "https://proxy.golang.org/github.com/spf13/pflag/@v/v1.0.5.zip": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:58806->[::1]:53: i/o timeout
github.com/stuntkit/stunt_gp_tools/pkg/texture imports
        github.com/gojuno/go.morton: github.com/gojuno/go.morton@v0.0.0-20180202102823-94709bd871ce: Get "https://proxy.golang.org/github.com/gojuno/go.morton/@v/v0.0.0-20180202102823-94709bd871ce.zip": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:58806->[::1]:53: i/o timeout
```

</details>


<details>

<summary>after</summary>

```text
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/gojuno/go.morton v0.0.0-20180202102823-94709bd871ce
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1e addr=0x18 pc=0x4be351]

goroutine 369 [running]:
io.ReadAtLeast({0x0, 0x0}, {0xc00022c380, 0x20, 0x20}, 0x20)
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/io/io.go:331 +0x71
io.ReadFull(...)
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/io/io.go:350
crypto/tls.(*Conn).makeClientHello(0xc00020c380)
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/crypto/tls/handshake_client.go:107 +0x7e5
crypto/tls.(*Conn).clientHandshake(0xc00020c380, {0xac9968, 0xc00032c240})
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/crypto/tls/handshake_client.go:154 +0x96
crypto/tls.(*Conn).handshakeContext(0xc00020c380, {0xac99a0, 0xc000122000})
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/crypto/tls/conn.go:1460 +0x32f
crypto/tls.(*Conn).HandshakeContext(...)
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/crypto/tls/conn.go:1403
net/http.(*persistConn).addTLS.func2()
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/net/http/transport.go:1537 +0x71
created by net/http.(*persistConn).addTLS
        /home/halamix2/repos/haiku/go-haiku-amd64-bootstrap/src/net/http/transport.go:1533 +0x345
```

</details>

Compiled under Linux, tested on mainstream x64 Haiku.

I don't really like how this code looks, but it allows us to go further and handle next errors:
Simply adding haiku to the `//go:build` of `src/crypto/rand/rand_unix.go` file is enough to make `go mod tidy` pass; compilation is still broken, but that's still progress